### PR TITLE
Updated prstats link

### DIFF
--- a/lib/widgets/custom_player_list.dart
+++ b/lib/widgets/custom_player_list.dart
@@ -270,7 +270,7 @@ class _CustomPlayerListState extends State<CustomPlayerList>
   ///
   void _openPlayerStats(Player player) {
     String encodedUri = Uri.encodeFull(
-      'https://prstats.tk/player/find?name=${player.prStatsNormalizedPlayerName}',
+      'https://prstats.realitymod.com/player/find?name=${player.prStatsNormalizedPlayerName}',
     );
     launchUrlString(encodedUri, mode: LaunchMode.externalApplication);
   }


### PR DESCRIPTION
Since prstats.tk is closing, this PR updates the link to player stats to the new official link (prstats.realitymod.com)